### PR TITLE
Fix branch name for staging deployment

### DIFF
--- a/.github/workflows/continuous-integration-and-delivery.yml
+++ b/.github/workflows/continuous-integration-and-delivery.yml
@@ -48,8 +48,8 @@ jobs:
           git push -f production origin/main:refs/heads/master
 
       - name: Deploy Staging
-        if: github.ref == 'refs/heads/chore/develop'
+        if: github.ref == 'refs/heads/develop'
         run: |
           git remote add staging https://heroku:$HEROKU_API_KEY@git.heroku.com/$HEROKU_STAGING_APP.git
-          git push -f staging origin/chore/develop:refs/heads/master
+          git push -f staging origin/develop:refs/heads/master
 


### PR DESCRIPTION
## What happened

The branch name on the CD configuration is wrong, so after the branch got merged Github Action didn't deploy them to the staging 🤦 

![Screen Shot 2563-11-17 at 12 45 19](https://user-images.githubusercontent.com/1772999/99351413-1a563580-28d3-11eb-95fe-0906eecc3262.png)

 
## Insight

N/A
 
## Proof Of Work

after merging this branch it should deploy on staging